### PR TITLE
Fix/remove manual check for logstash member

### DIFF
--- a/lib/lita-jls/util.rb
+++ b/lib/lita-jls/util.rb
@@ -71,7 +71,6 @@ module LitaJLS
       begin
         git(".", "clone", url, cache)
       rescue => e
-        puts "!cache: #{cache}"
         logger.debug("clone_at failed, trying to open repo instead", :cache => cache, :error => e)
         git(cache, "log", "-n0") # Verify some kind of git works here
       end

--- a/lib/lita-jls/util.rb
+++ b/lib/lita-jls/util.rb
@@ -34,15 +34,7 @@ module LitaJLS
       # TODO(sissel): json exception? .get exception?
 
       if check["status"] == "error"
-        # The CLA checker doesn't know about Elasticsearch employees,
-        # so let's work around that problem.
-        github = Faraday.new(:url => "https://api.github.com")
-        response = github.get("/repos/#{repository}/pulls/#{pr}")
-        pr_data = JSON.parse(response.body)
-
-        if !logstash_team?(pr_data["user"]["login"])
-          raise CLANotSigned, check["message"]
-        end
+        raise CLANotSigned, check["message"]
       end
 
       true
@@ -79,6 +71,7 @@ module LitaJLS
       begin
         git(".", "clone", url, cache)
       rescue => e
+        puts "!cache: #{cache}"
         logger.debug("clone_at failed, trying to open repo instead", :cache => cache, :error => e)
         git(cache, "log", "-n0") # Verify some kind of git works here
       end

--- a/spec/fixtures/vcr_cassettes/fetch_version_of_logstash-output-s3.yml
+++ b/spec/fixtures/vcr_cassettes/fetch_version_of_logstash-output-s3.yml
@@ -14,8 +14,6 @@ http_interactions:
       User-Agent:
       - Gems 0.8.3
       - Ruby
-      Authorization:
-      - 953b0543ac7ee8528d2a14f263615e33
       Connection:
       - keep-alive
       Keep-Alive:
@@ -30,7 +28,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Tue, 02 Dec 2014 14:56:21 GMT
+      - Tue, 16 Dec 2014 16:12:50 GMT
       Content-Type:
       - text/yaml
       Transfer-Encoding:
@@ -54,12 +52,10 @@ http_interactions:
       X-Ua-Compatible:
       - IE=Edge,chrome=1
       - IE=Edge,chrome=1
-      Set-Cookie:
-      - remember_token=; path=/; expires=Wed, 02-Dec-2015 14:56:21 GMT; secure
       X-Request-Id:
-      - 99c8f8cc6a0d1c01b5b168edb1012a82
+      - e726d0892877a0b310402be784f88add
       X-Runtime:
-      - '0.010505'
+      - '0.012082'
       X-Rack-Cache:
       - miss
     body:
@@ -71,7 +67,7 @@ http_interactions:
           description: This gem is a logstash plugin required to be installed on top of the
             Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is
             not a stand-alone program
-          downloads_count: 245
+          downloads_count: 479
           number: 0.1.1
           summary: This plugin was created for store the logstash's events into Amazon Simple
             Storage Service (Amazon S3)
@@ -85,7 +81,7 @@ http_interactions:
           built_at: '2014-11-06T00:00:00Z'
           description: This plugin was created for store the logstash's events into Amazon
             Simple Storage Service (Amazon S3)
-          downloads_count: 178
+          downloads_count: 195
           number: 0.1.0
           summary: This plugin was created for store the logstash's events into Amazon Simple
             Storage Service (Amazon S3)
@@ -96,5 +92,5 @@ http_interactions:
           - Apache License (2.0)
           requirements: []
     http_version: 
-  recorded_at: Tue, 02 Dec 2014 14:56:21 GMT
+  recorded_at: Tue, 16 Dec 2014 16:12:51 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/gem_doesnt_exist.yml
+++ b/spec/fixtures/vcr_cassettes/gem_doesnt_exist.yml
@@ -14,8 +14,6 @@ http_interactions:
       User-Agent:
       - Gems 0.8.3
       - Ruby
-      Authorization:
-      - 953b0543ac7ee8528d2a14f263615e33
       Connection:
       - keep-alive
       Keep-Alive:
@@ -30,7 +28,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Tue, 02 Dec 2014 14:56:21 GMT
+      - Tue, 16 Dec 2014 16:12:51 GMT
       Content-Type:
       - application/x-yaml; charset=utf-8
       Transfer-Encoding:
@@ -45,17 +43,15 @@ http_interactions:
       - IE=Edge,chrome=1
       Cache-Control:
       - no-cache, private
-      Set-Cookie:
-      - remember_token=; path=/; expires=Wed, 02-Dec-2015 14:56:21 GMT; secure
       X-Request-Id:
-      - 782b7237bf1635785132a70d10a39323
+      - 11452fa565f746c1633fc8f219167984
       X-Runtime:
-      - '0.004458'
+      - '0.005424'
       X-Rack-Cache:
       - miss
     body:
       encoding: UTF-8
       string: This rubygem could not be found.
     http_version: 
-  recorded_at: Tue, 02 Dec 2014 14:56:21 GMT
+  recorded_at: Tue, 16 Dec 2014 16:12:51 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/successful_clacheck.yml
+++ b/spec/fixtures/vcr_cassettes/successful_clacheck.yml
@@ -21,7 +21,7 @@ http_interactions:
       Server:
       - nginx/1.4.6 (Ubuntu)
       Date:
-      - Tue, 16 Dec 2014 16:18:14 GMT
+      - Mon, 05 Jan 2015 21:31:30 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -39,7 +39,7 @@ http_interactions:
       string: '{"status":"success","status_human":"Success","message":"All commit
         authors have signed the CLA or are members of Elasticsearch"}'
     http_version: 
-  recorded_at: Tue, 16 Dec 2014 16:13:15 GMT
+  recorded_at: Mon, 05 Jan 2015 21:25:36 GMT
 - request:
     method: get
     uri: https://test.local/jordansissel/this-is-only-a-test/pull/1.patch
@@ -61,7 +61,7 @@ http_interactions:
       Server:
       - GitHub.com
       Date:
-      - Tue, 16 Dec 2014 16:13:16 GMT
+      - Mon, 05 Jan 2015 21:25:37 GMT
       Content-Type:
       - text/plain; charset=utf-8
       Transfer-Encoding:
@@ -89,19 +89,19 @@ http_interactions:
       X-Ua-Compatible:
       - IE=Edge,chrome=1
       X-Request-Id:
-      - dc1189097bdb61e32dcce19e78e60348
+      - c7b7a0a0845e9dfde70a55bd614927ca
       X-Runtime:
-      - '0.033517'
+      - '0.040710'
       X-Rack-Cache:
       - miss
       X-Github-Request-Id:
-      - 428224B6:11C0:19FAFA9:54905A1C
+      - C0DEBD91:481D:15EA456:54AB0151
       Strict-Transport-Security:
       - max-age=31536000; includeSubdomains; preload
       X-Content-Type-Options:
       - nosniff
       X-Served-By:
-      - e68303a089d42a09a9545cb48f3ff7a6
+      - 44f77bef9757b092723b0a6870733b02
     body:
       encoding: UTF-8
       string: |
@@ -123,5 +123,5 @@ http_interactions:
         @@ -0,0 +1 @@
         +Thu Sep 25 22:39:11 UTC 2014
     http_version: 
-  recorded_at: Tue, 16 Dec 2014 16:13:16 GMT
+  recorded_at: Mon, 05 Jan 2015 21:25:37 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/successful_clacheck.yml
+++ b/spec/fixtures/vcr_cassettes/successful_clacheck.yml
@@ -21,11 +21,11 @@ http_interactions:
       Server:
       - nginx/1.4.6 (Ubuntu)
       Date:
-      - Tue, 02 Dec 2014 15:01:17 GMT
+      - Tue, 16 Dec 2014 16:18:14 GMT
       Content-Type:
       - application/json
       Content-Length:
-      - '241'
+      - '128'
       Connection:
       - keep-alive
       Access-Control-Allow-Origin:
@@ -36,15 +36,13 @@ http_interactions:
       - nosniff
     body:
       encoding: UTF-8
-      string: '{"status":"error","status_human":"Error","message":"Not all commit
-        authors have signed the CLA.","commits":[{"sha":"6fe527c7","subject":"Happy
-        little message","nickname":"jordansissel","email":"jls@semicomplete.com","name":"Jordan
-        Sissel"}]}'
+      string: '{"status":"success","status_human":"Success","message":"All commit
+        authors have signed the CLA or are members of Elasticsearch"}'
     http_version: 
-  recorded_at: Tue, 02 Dec 2014 14:56:56 GMT
+  recorded_at: Tue, 16 Dec 2014 16:13:15 GMT
 - request:
     method: get
-    uri: https://api.github.com/repos/jordansissel/this-is-only-a-test/pulls/1
+    uri: https://test.local/jordansissel/this-is-only-a-test/pull/1.patch
     body:
       encoding: US-ASCII
       string: ''
@@ -63,80 +61,7 @@ http_interactions:
       Server:
       - GitHub.com
       Date:
-      - Tue, 02 Dec 2014 14:56:56 GMT
-      Content-Type:
-      - application/json; charset=utf-8
-      Transfer-Encoding:
-      - chunked
-      Status:
-      - 200 OK
-      X-Ratelimit-Limit:
-      - '60'
-      X-Ratelimit-Remaining:
-      - '57'
-      X-Ratelimit-Reset:
-      - '1417535080'
-      Cache-Control:
-      - public, max-age=60, s-maxage=60
-      Last-Modified:
-      - Tue, 02 Dec 2014 12:10:03 GMT
-      Etag:
-      - '"776d8b5b2b7ef7b3d48d53f05c602687"'
-      Vary:
-      - Accept
-      - Accept-Encoding
-      X-Github-Media-Type:
-      - github.v3
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - deny
-      Content-Security-Policy:
-      - default-src 'none'
-      Access-Control-Allow-Credentials:
-      - 'true'
-      Access-Control-Expose-Headers:
-      - ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
-        X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
-      Access-Control-Allow-Origin:
-      - "*"
-      X-Github-Request-Id:
-      - 60178CA6:15D5:4C5FCE3:547DD338
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubdomains; preload
-      X-Content-Type-Options:
-      - nosniff
-      X-Served-By:
-      - 474556b853193c38f1b14328ce2d1b7d
-    body:
-      encoding: UTF-8
-      string: '{"url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/pulls/1","id":21817876,"html_url":"https://github.com/jordansissel/this-is-only-a-test/pull/1","diff_url":"https://github.com/jordansissel/this-is-only-a-test/pull/1.diff","patch_url":"https://github.com/jordansissel/this-is-only-a-test/pull/1.patch","issue_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/issues/1","number":1,"state":"open","locked":false,"title":".","user":{"login":"jordansissel","id":131818,"avatar_url":"https://avatars.githubusercontent.com/u/131818?v=3","gravatar_id":"","url":"https://api.github.com/users/jordansissel","html_url":"https://github.com/jordansissel","followers_url":"https://api.github.com/users/jordansissel/followers","following_url":"https://api.github.com/users/jordansissel/following{/other_user}","gists_url":"https://api.github.com/users/jordansissel/gists{/gist_id}","starred_url":"https://api.github.com/users/jordansissel/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/jordansissel/subscriptions","organizations_url":"https://api.github.com/users/jordansissel/orgs","repos_url":"https://api.github.com/users/jordansissel/repos","events_url":"https://api.github.com/users/jordansissel/events{/privacy}","received_events_url":"https://api.github.com/users/jordansissel/received_events","type":"User","site_admin":false},"body":"","created_at":"2014-09-25T22:39:24Z","updated_at":"2014-09-27T05:26:36Z","closed_at":null,"merged_at":null,"merge_commit_sha":"60145ac836bff1303ec8b0464124fd0855b06358","assignee":null,"milestone":null,"commits_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/pulls/1/commits","review_comments_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/pulls/1/comments","review_comment_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/pulls/comments/{number}","comments_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/issues/1/comments","statuses_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/statuses/6fe527c79a546da6d623b33a001405c3473addbd","head":{"label":"jordansissel:testbranch","ref":"testbranch","sha":"6fe527c79a546da6d623b33a001405c3473addbd","user":{"login":"jordansissel","id":131818,"avatar_url":"https://avatars.githubusercontent.com/u/131818?v=3","gravatar_id":"","url":"https://api.github.com/users/jordansissel","html_url":"https://github.com/jordansissel","followers_url":"https://api.github.com/users/jordansissel/followers","following_url":"https://api.github.com/users/jordansissel/following{/other_user}","gists_url":"https://api.github.com/users/jordansissel/gists{/gist_id}","starred_url":"https://api.github.com/users/jordansissel/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/jordansissel/subscriptions","organizations_url":"https://api.github.com/users/jordansissel/orgs","repos_url":"https://api.github.com/users/jordansissel/repos","events_url":"https://api.github.com/users/jordansissel/events{/privacy}","received_events_url":"https://api.github.com/users/jordansissel/received_events","type":"User","site_admin":false},"repo":{"id":24477778,"name":"this-is-only-a-test","full_name":"jordansissel/this-is-only-a-test","owner":{"login":"jordansissel","id":131818,"avatar_url":"https://avatars.githubusercontent.com/u/131818?v=3","gravatar_id":"","url":"https://api.github.com/users/jordansissel","html_url":"https://github.com/jordansissel","followers_url":"https://api.github.com/users/jordansissel/followers","following_url":"https://api.github.com/users/jordansissel/following{/other_user}","gists_url":"https://api.github.com/users/jordansissel/gists{/gist_id}","starred_url":"https://api.github.com/users/jordansissel/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/jordansissel/subscriptions","organizations_url":"https://api.github.com/users/jordansissel/orgs","repos_url":"https://api.github.com/users/jordansissel/repos","events_url":"https://api.github.com/users/jordansissel/events{/privacy}","received_events_url":"https://api.github.com/users/jordansissel/received_events","type":"User","site_admin":false},"private":false,"html_url":"https://github.com/jordansissel/this-is-only-a-test","description":"This
-        is only a test. I promise!","fork":false,"url":"https://api.github.com/repos/jordansissel/this-is-only-a-test","forks_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/forks","keys_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/keys{/key_id}","collaborators_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/teams","hooks_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/hooks","issue_events_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/issues/events{/number}","events_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/events","assignees_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/assignees{/user}","branches_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/branches{/branch}","tags_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/tags","blobs_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/git/refs{/sha}","trees_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/git/trees{/sha}","statuses_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/statuses/{sha}","languages_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/languages","stargazers_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/stargazers","contributors_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/contributors","subscribers_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/subscribers","subscription_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/subscription","commits_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/commits{/sha}","git_commits_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/git/commits{/sha}","comments_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/comments{/number}","issue_comment_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/issues/comments/{number}","contents_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/contents/{+path}","compare_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/compare/{base}...{head}","merges_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/merges","archive_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/downloads","issues_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/issues{/number}","pulls_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/pulls{/number}","milestones_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/milestones{/number}","notifications_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/labels{/name}","releases_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/releases{/id}","created_at":"2014-09-25T22:38:00Z","updated_at":"2014-09-27T04:08:59Z","pushed_at":"2014-09-27T05:26:36Z","git_url":"git://github.com/jordansissel/this-is-only-a-test.git","ssh_url":"git@github.com:jordansissel/this-is-only-a-test.git","clone_url":"https://github.com/jordansissel/this-is-only-a-test.git","svn_url":"https://github.com/jordansissel/this-is-only-a-test","homepage":"","size":232,"stargazers_count":0,"watchers_count":0,"language":null,"has_issues":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":0,"mirror_url":null,"open_issues_count":4,"forks":0,"open_issues":4,"watchers":0,"default_branch":"master"}},"base":{"label":"jordansissel:master","ref":"master","sha":"1a2be1160aa1a6bbb984ef7b60fd02882b341bf2","user":{"login":"jordansissel","id":131818,"avatar_url":"https://avatars.githubusercontent.com/u/131818?v=3","gravatar_id":"","url":"https://api.github.com/users/jordansissel","html_url":"https://github.com/jordansissel","followers_url":"https://api.github.com/users/jordansissel/followers","following_url":"https://api.github.com/users/jordansissel/following{/other_user}","gists_url":"https://api.github.com/users/jordansissel/gists{/gist_id}","starred_url":"https://api.github.com/users/jordansissel/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/jordansissel/subscriptions","organizations_url":"https://api.github.com/users/jordansissel/orgs","repos_url":"https://api.github.com/users/jordansissel/repos","events_url":"https://api.github.com/users/jordansissel/events{/privacy}","received_events_url":"https://api.github.com/users/jordansissel/received_events","type":"User","site_admin":false},"repo":{"id":24477778,"name":"this-is-only-a-test","full_name":"jordansissel/this-is-only-a-test","owner":{"login":"jordansissel","id":131818,"avatar_url":"https://avatars.githubusercontent.com/u/131818?v=3","gravatar_id":"","url":"https://api.github.com/users/jordansissel","html_url":"https://github.com/jordansissel","followers_url":"https://api.github.com/users/jordansissel/followers","following_url":"https://api.github.com/users/jordansissel/following{/other_user}","gists_url":"https://api.github.com/users/jordansissel/gists{/gist_id}","starred_url":"https://api.github.com/users/jordansissel/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/jordansissel/subscriptions","organizations_url":"https://api.github.com/users/jordansissel/orgs","repos_url":"https://api.github.com/users/jordansissel/repos","events_url":"https://api.github.com/users/jordansissel/events{/privacy}","received_events_url":"https://api.github.com/users/jordansissel/received_events","type":"User","site_admin":false},"private":false,"html_url":"https://github.com/jordansissel/this-is-only-a-test","description":"This
-        is only a test. I promise!","fork":false,"url":"https://api.github.com/repos/jordansissel/this-is-only-a-test","forks_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/forks","keys_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/keys{/key_id}","collaborators_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/teams","hooks_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/hooks","issue_events_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/issues/events{/number}","events_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/events","assignees_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/assignees{/user}","branches_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/branches{/branch}","tags_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/tags","blobs_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/git/refs{/sha}","trees_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/git/trees{/sha}","statuses_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/statuses/{sha}","languages_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/languages","stargazers_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/stargazers","contributors_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/contributors","subscribers_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/subscribers","subscription_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/subscription","commits_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/commits{/sha}","git_commits_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/git/commits{/sha}","comments_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/comments{/number}","issue_comment_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/issues/comments/{number}","contents_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/contents/{+path}","compare_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/compare/{base}...{head}","merges_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/merges","archive_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/downloads","issues_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/issues{/number}","pulls_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/pulls{/number}","milestones_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/milestones{/number}","notifications_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/labels{/name}","releases_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/releases{/id}","created_at":"2014-09-25T22:38:00Z","updated_at":"2014-09-27T04:08:59Z","pushed_at":"2014-09-27T05:26:36Z","git_url":"git://github.com/jordansissel/this-is-only-a-test.git","ssh_url":"git@github.com:jordansissel/this-is-only-a-test.git","clone_url":"https://github.com/jordansissel/this-is-only-a-test.git","svn_url":"https://github.com/jordansissel/this-is-only-a-test","homepage":"","size":232,"stargazers_count":0,"watchers_count":0,"language":null,"has_issues":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":0,"mirror_url":null,"open_issues_count":4,"forks":0,"open_issues":4,"watchers":0,"default_branch":"master"}},"_links":{"self":{"href":"https://api.github.com/repos/jordansissel/this-is-only-a-test/pulls/1"},"html":{"href":"https://github.com/jordansissel/this-is-only-a-test/pull/1"},"issue":{"href":"https://api.github.com/repos/jordansissel/this-is-only-a-test/issues/1"},"comments":{"href":"https://api.github.com/repos/jordansissel/this-is-only-a-test/issues/1/comments"},"review_comments":{"href":"https://api.github.com/repos/jordansissel/this-is-only-a-test/pulls/1/comments"},"review_comment":{"href":"https://api.github.com/repos/jordansissel/this-is-only-a-test/pulls/comments/{number}"},"commits":{"href":"https://api.github.com/repos/jordansissel/this-is-only-a-test/pulls/1/commits"},"statuses":{"href":"https://api.github.com/repos/jordansissel/this-is-only-a-test/statuses/6fe527c79a546da6d623b33a001405c3473addbd"}},"merged":false,"mergeable":true,"mergeable_state":"clean","merged_by":null,"comments":0,"review_comments":0,"commits":1,"additions":1,"deletions":0,"changed_files":1}'
-    http_version: 
-  recorded_at: Tue, 02 Dec 2014 14:56:56 GMT
-- request:
-    method: get
-    uri: https://github.com/jordansissel/this-is-only-a-test/pull/1.patch
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Faraday v0.9.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - GitHub.com
-      Date:
-      - Tue, 02 Dec 2014 14:56:57 GMT
+      - Tue, 16 Dec 2014 16:13:16 GMT
       Content-Type:
       - text/plain; charset=utf-8
       Transfer-Encoding:
@@ -163,25 +88,20 @@ http_interactions:
       - X-PJAX
       X-Ua-Compatible:
       - IE=Edge,chrome=1
-      Set-Cookie:
-      - _gh_sess=eyJzZXNzaW9uX2lkIjoiZDEyYmU4OGI5NTUxZmVhODUzNDFmY2FjNmJlN2IxNWEiLCJzcHlfcmVwbyI6ImpvcmRhbnNpc3NlbC90aGlzLWlzLW9ubHktYS10ZXN0Iiwic3B5X3JlcG9fYXQiOjE0MTc1MzIyMTd9--aedeaf0de3027a3ee6b88dd69500cb0236089994;
-        path=/; secure; HttpOnly
-      - logged_in=no; domain=.github.com; path=/; expires=Sat, 02-Dec-2034 14:56:57
-        GMT; secure; HttpOnly
       X-Request-Id:
-      - b10e44eae77f7b8745520dab06b3c2ef
+      - dc1189097bdb61e32dcce19e78e60348
       X-Runtime:
-      - '0.030616'
+      - '0.033517'
       X-Rack-Cache:
       - miss
       X-Github-Request-Id:
-      - 60178CA6:15D6:68D3989:547DD339
+      - 428224B6:11C0:19FAFA9:54905A1C
       Strict-Transport-Security:
       - max-age=31536000; includeSubdomains; preload
       X-Content-Type-Options:
       - nosniff
       X-Served-By:
-      - 9835a984a05caa405eb61faaa1546741
+      - e68303a089d42a09a9545cb48f3ff7a6
     body:
       encoding: UTF-8
       string: |
@@ -203,5 +123,5 @@ http_interactions:
         @@ -0,0 +1 @@
         +Thu Sep 25 22:39:11 UTC 2014
     http_version: 
-  recorded_at: Tue, 02 Dec 2014 14:56:57 GMT
+  recorded_at: Tue, 16 Dec 2014 16:13:16 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/successful_clacheck_long_commit.yml
+++ b/spec/fixtures/vcr_cassettes/successful_clacheck_long_commit.yml
@@ -21,11 +21,11 @@ http_interactions:
       Server:
       - nginx/1.4.6 (Ubuntu)
       Date:
-      - Tue, 02 Dec 2014 15:01:19 GMT
+      - Tue, 16 Dec 2014 16:18:16 GMT
       Content-Type:
       - application/json
       Content-Length:
-      - '261'
+      - '128'
       Connection:
       - keep-alive
       Access-Control-Allow-Origin:
@@ -36,15 +36,13 @@ http_interactions:
       - nosniff
     body:
       encoding: UTF-8
-      string: '{"status":"error","status_human":"Error","message":"Not all commit
-        authors have signed the CLA.","commits":[{"sha":"6aa67f48","subject":"One
-        two three four five six seven eight.","nickname":"jordansissel","email":"jls@semicomplete.com","name":"Jordan
-        Sissel"}]}'
+      string: '{"status":"success","status_human":"Success","message":"All commit
+        authors have signed the CLA or are members of Elasticsearch"}'
     http_version: 
-  recorded_at: Tue, 02 Dec 2014 14:56:58 GMT
+  recorded_at: Tue, 16 Dec 2014 16:13:18 GMT
 - request:
     method: get
-    uri: https://api.github.com/repos/jordansissel/this-is-only-a-test/pulls/4
+    uri: https://test.local/jordansissel/this-is-only-a-test/pull/4.patch
     body:
       encoding: US-ASCII
       string: ''
@@ -63,82 +61,7 @@ http_interactions:
       Server:
       - GitHub.com
       Date:
-      - Tue, 02 Dec 2014 14:56:58 GMT
-      Content-Type:
-      - application/json; charset=utf-8
-      Transfer-Encoding:
-      - chunked
-      Status:
-      - 200 OK
-      X-Ratelimit-Limit:
-      - '60'
-      X-Ratelimit-Remaining:
-      - '56'
-      X-Ratelimit-Reset:
-      - '1417535080'
-      Cache-Control:
-      - public, max-age=60, s-maxage=60
-      Last-Modified:
-      - Tue, 02 Dec 2014 12:10:03 GMT
-      Etag:
-      - '"83e128a2027d04c2087337731a6cec70"'
-      Vary:
-      - Accept
-      - Accept-Encoding
-      X-Github-Media-Type:
-      - github.v3
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - deny
-      Content-Security-Policy:
-      - default-src 'none'
-      Access-Control-Allow-Credentials:
-      - 'true'
-      Access-Control-Expose-Headers:
-      - ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
-        X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
-      Access-Control-Allow-Origin:
-      - "*"
-      X-Github-Request-Id:
-      - 60178CA6:15D4:2FF4973:547DD33A
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubdomains; preload
-      X-Content-Type-Options:
-      - nosniff
-      X-Served-By:
-      - 065b43cd9674091fec48a221b420fbb3
-    body:
-      encoding: UTF-8
-      string: '{"url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/pulls/4","id":21885986,"html_url":"https://github.com/jordansissel/this-is-only-a-test/pull/4","diff_url":"https://github.com/jordansissel/this-is-only-a-test/pull/4.diff","patch_url":"https://github.com/jordansissel/this-is-only-a-test/pull/4.patch","issue_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/issues/4","number":4,"state":"open","locked":false,"title":"One
-        two three four five six seven eight.","user":{"login":"jordansissel","id":131818,"avatar_url":"https://avatars.githubusercontent.com/u/131818?v=3","gravatar_id":"","url":"https://api.github.com/users/jordansissel","html_url":"https://github.com/jordansissel","followers_url":"https://api.github.com/users/jordansissel/followers","following_url":"https://api.github.com/users/jordansissel/following{/other_user}","gists_url":"https://api.github.com/users/jordansissel/gists{/gist_id}","starred_url":"https://api.github.com/users/jordansissel/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/jordansissel/subscriptions","organizations_url":"https://api.github.com/users/jordansissel/orgs","repos_url":"https://api.github.com/users/jordansissel/repos","events_url":"https://api.github.com/users/jordansissel/events{/privacy}","received_events_url":"https://api.github.com/users/jordansissel/received_events","type":"User","site_admin":false},"body":"Nine
-        ten eleven.\r\n\r\nTwelve?\r\n* Thirteen\r\n* Fourteen","created_at":"2014-09-27T05:00:30Z","updated_at":"2014-09-29T22:15:04Z","closed_at":null,"merged_at":null,"merge_commit_sha":"5610d79a6219e24fc83af7efc4380498140b29be","assignee":null,"milestone":null,"commits_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/pulls/4/commits","review_comments_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/pulls/4/comments","review_comment_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/pulls/comments/{number}","comments_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/issues/4/comments","statuses_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/statuses/6aa67f489306e0ea28d1b47421006278b2ca08ec","head":{"label":"jordansissel:long","ref":"long","sha":"6aa67f489306e0ea28d1b47421006278b2ca08ec","user":{"login":"jordansissel","id":131818,"avatar_url":"https://avatars.githubusercontent.com/u/131818?v=3","gravatar_id":"","url":"https://api.github.com/users/jordansissel","html_url":"https://github.com/jordansissel","followers_url":"https://api.github.com/users/jordansissel/followers","following_url":"https://api.github.com/users/jordansissel/following{/other_user}","gists_url":"https://api.github.com/users/jordansissel/gists{/gist_id}","starred_url":"https://api.github.com/users/jordansissel/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/jordansissel/subscriptions","organizations_url":"https://api.github.com/users/jordansissel/orgs","repos_url":"https://api.github.com/users/jordansissel/repos","events_url":"https://api.github.com/users/jordansissel/events{/privacy}","received_events_url":"https://api.github.com/users/jordansissel/received_events","type":"User","site_admin":false},"repo":{"id":24477778,"name":"this-is-only-a-test","full_name":"jordansissel/this-is-only-a-test","owner":{"login":"jordansissel","id":131818,"avatar_url":"https://avatars.githubusercontent.com/u/131818?v=3","gravatar_id":"","url":"https://api.github.com/users/jordansissel","html_url":"https://github.com/jordansissel","followers_url":"https://api.github.com/users/jordansissel/followers","following_url":"https://api.github.com/users/jordansissel/following{/other_user}","gists_url":"https://api.github.com/users/jordansissel/gists{/gist_id}","starred_url":"https://api.github.com/users/jordansissel/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/jordansissel/subscriptions","organizations_url":"https://api.github.com/users/jordansissel/orgs","repos_url":"https://api.github.com/users/jordansissel/repos","events_url":"https://api.github.com/users/jordansissel/events{/privacy}","received_events_url":"https://api.github.com/users/jordansissel/received_events","type":"User","site_admin":false},"private":false,"html_url":"https://github.com/jordansissel/this-is-only-a-test","description":"This
-        is only a test. I promise!","fork":false,"url":"https://api.github.com/repos/jordansissel/this-is-only-a-test","forks_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/forks","keys_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/keys{/key_id}","collaborators_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/teams","hooks_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/hooks","issue_events_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/issues/events{/number}","events_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/events","assignees_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/assignees{/user}","branches_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/branches{/branch}","tags_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/tags","blobs_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/git/refs{/sha}","trees_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/git/trees{/sha}","statuses_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/statuses/{sha}","languages_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/languages","stargazers_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/stargazers","contributors_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/contributors","subscribers_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/subscribers","subscription_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/subscription","commits_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/commits{/sha}","git_commits_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/git/commits{/sha}","comments_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/comments{/number}","issue_comment_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/issues/comments/{number}","contents_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/contents/{+path}","compare_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/compare/{base}...{head}","merges_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/merges","archive_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/downloads","issues_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/issues{/number}","pulls_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/pulls{/number}","milestones_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/milestones{/number}","notifications_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/labels{/name}","releases_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/releases{/id}","created_at":"2014-09-25T22:38:00Z","updated_at":"2014-09-27T04:08:59Z","pushed_at":"2014-09-27T05:26:36Z","git_url":"git://github.com/jordansissel/this-is-only-a-test.git","ssh_url":"git@github.com:jordansissel/this-is-only-a-test.git","clone_url":"https://github.com/jordansissel/this-is-only-a-test.git","svn_url":"https://github.com/jordansissel/this-is-only-a-test","homepage":"","size":232,"stargazers_count":0,"watchers_count":0,"language":null,"has_issues":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":0,"mirror_url":null,"open_issues_count":4,"forks":0,"open_issues":4,"watchers":0,"default_branch":"master"}},"base":{"label":"jordansissel:master","ref":"master","sha":"1a2be1160aa1a6bbb984ef7b60fd02882b341bf2","user":{"login":"jordansissel","id":131818,"avatar_url":"https://avatars.githubusercontent.com/u/131818?v=3","gravatar_id":"","url":"https://api.github.com/users/jordansissel","html_url":"https://github.com/jordansissel","followers_url":"https://api.github.com/users/jordansissel/followers","following_url":"https://api.github.com/users/jordansissel/following{/other_user}","gists_url":"https://api.github.com/users/jordansissel/gists{/gist_id}","starred_url":"https://api.github.com/users/jordansissel/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/jordansissel/subscriptions","organizations_url":"https://api.github.com/users/jordansissel/orgs","repos_url":"https://api.github.com/users/jordansissel/repos","events_url":"https://api.github.com/users/jordansissel/events{/privacy}","received_events_url":"https://api.github.com/users/jordansissel/received_events","type":"User","site_admin":false},"repo":{"id":24477778,"name":"this-is-only-a-test","full_name":"jordansissel/this-is-only-a-test","owner":{"login":"jordansissel","id":131818,"avatar_url":"https://avatars.githubusercontent.com/u/131818?v=3","gravatar_id":"","url":"https://api.github.com/users/jordansissel","html_url":"https://github.com/jordansissel","followers_url":"https://api.github.com/users/jordansissel/followers","following_url":"https://api.github.com/users/jordansissel/following{/other_user}","gists_url":"https://api.github.com/users/jordansissel/gists{/gist_id}","starred_url":"https://api.github.com/users/jordansissel/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/jordansissel/subscriptions","organizations_url":"https://api.github.com/users/jordansissel/orgs","repos_url":"https://api.github.com/users/jordansissel/repos","events_url":"https://api.github.com/users/jordansissel/events{/privacy}","received_events_url":"https://api.github.com/users/jordansissel/received_events","type":"User","site_admin":false},"private":false,"html_url":"https://github.com/jordansissel/this-is-only-a-test","description":"This
-        is only a test. I promise!","fork":false,"url":"https://api.github.com/repos/jordansissel/this-is-only-a-test","forks_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/forks","keys_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/keys{/key_id}","collaborators_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/teams","hooks_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/hooks","issue_events_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/issues/events{/number}","events_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/events","assignees_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/assignees{/user}","branches_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/branches{/branch}","tags_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/tags","blobs_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/git/refs{/sha}","trees_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/git/trees{/sha}","statuses_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/statuses/{sha}","languages_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/languages","stargazers_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/stargazers","contributors_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/contributors","subscribers_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/subscribers","subscription_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/subscription","commits_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/commits{/sha}","git_commits_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/git/commits{/sha}","comments_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/comments{/number}","issue_comment_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/issues/comments/{number}","contents_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/contents/{+path}","compare_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/compare/{base}...{head}","merges_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/merges","archive_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/downloads","issues_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/issues{/number}","pulls_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/pulls{/number}","milestones_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/milestones{/number}","notifications_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/labels{/name}","releases_url":"https://api.github.com/repos/jordansissel/this-is-only-a-test/releases{/id}","created_at":"2014-09-25T22:38:00Z","updated_at":"2014-09-27T04:08:59Z","pushed_at":"2014-09-27T05:26:36Z","git_url":"git://github.com/jordansissel/this-is-only-a-test.git","ssh_url":"git@github.com:jordansissel/this-is-only-a-test.git","clone_url":"https://github.com/jordansissel/this-is-only-a-test.git","svn_url":"https://github.com/jordansissel/this-is-only-a-test","homepage":"","size":232,"stargazers_count":0,"watchers_count":0,"language":null,"has_issues":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":0,"mirror_url":null,"open_issues_count":4,"forks":0,"open_issues":4,"watchers":0,"default_branch":"master"}},"_links":{"self":{"href":"https://api.github.com/repos/jordansissel/this-is-only-a-test/pulls/4"},"html":{"href":"https://github.com/jordansissel/this-is-only-a-test/pull/4"},"issue":{"href":"https://api.github.com/repos/jordansissel/this-is-only-a-test/issues/4"},"comments":{"href":"https://api.github.com/repos/jordansissel/this-is-only-a-test/issues/4/comments"},"review_comments":{"href":"https://api.github.com/repos/jordansissel/this-is-only-a-test/pulls/4/comments"},"review_comment":{"href":"https://api.github.com/repos/jordansissel/this-is-only-a-test/pulls/comments/{number}"},"commits":{"href":"https://api.github.com/repos/jordansissel/this-is-only-a-test/pulls/4/commits"},"statuses":{"href":"https://api.github.com/repos/jordansissel/this-is-only-a-test/statuses/6aa67f489306e0ea28d1b47421006278b2ca08ec"}},"merged":false,"mergeable":true,"mergeable_state":"clean","merged_by":null,"comments":0,"review_comments":0,"commits":1,"additions":1,"deletions":1,"changed_files":1}'
-    http_version: 
-  recorded_at: Tue, 02 Dec 2014 14:56:58 GMT
-- request:
-    method: get
-    uri: https://github.com/jordansissel/this-is-only-a-test/pull/4.patch
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Faraday v0.9.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - GitHub.com
-      Date:
-      - Tue, 02 Dec 2014 14:56:59 GMT
+      - Tue, 16 Dec 2014 16:13:18 GMT
       Content-Type:
       - text/plain; charset=utf-8
       Transfer-Encoding:
@@ -165,25 +88,20 @@ http_interactions:
       - X-PJAX
       X-Ua-Compatible:
       - IE=Edge,chrome=1
-      Set-Cookie:
-      - _gh_sess=eyJzZXNzaW9uX2lkIjoiNDc0Njc1YjcxMGNiYWU4MDA0MjJkMjIzN2RlMDVkOGYiLCJzcHlfcmVwbyI6ImpvcmRhbnNpc3NlbC90aGlzLWlzLW9ubHktYS10ZXN0Iiwic3B5X3JlcG9fYXQiOjE0MTc1MzIyMTl9--adbc4238f539f6d11aa4169844aa46cd8fb091bc;
-        path=/; secure; HttpOnly
-      - logged_in=no; domain=.github.com; path=/; expires=Sat, 02-Dec-2034 14:56:59
-        GMT; secure; HttpOnly
       X-Request-Id:
-      - af4e095618b9d4e8ac920324b54c87f5
+      - e01aa6416dc9414b519df3ff5afb8249
       X-Runtime:
-      - '0.039122'
+      - '0.031448'
       X-Rack-Cache:
       - miss
       X-Github-Request-Id:
-      - 60178CA6:15D6:68D3CBB:547DD33B
+      - 428224B6:11C0:19FB394:54905A1E
       Strict-Transport-Security:
       - max-age=31536000; includeSubdomains; preload
       X-Content-Type-Options:
       - nosniff
       X-Served-By:
-      - 63914e33d55e1647962cf498030a7c16
+      - a128136e4734a9f74c013356c773ece7
     body:
       encoding: UTF-8
       string: |
@@ -211,67 +129,5 @@ http_interactions:
         +Long commit?
          Sat Sep 27 04:42:57 UTC 2014
     http_version: 
-  recorded_at: Tue, 02 Dec 2014 14:56:59 GMT
-- request:
-    method: post
-    uri: https://ph:zodac90@api.github.com/repos/jordansissel/this-is-only-a-test/issues/4/labels
-    body:
-      encoding: UTF-8
-      string: "[]"
-    headers:
-      Accept:
-      - application/vnd.github.v3+json
-      User-Agent:
-      - Octokit Ruby Gem 3.5.2
-      Content-Type:
-      - application/json
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Server:
-      - GitHub.com
-      Date:
-      - Tue, 02 Dec 2014 14:57:00 GMT
-      Content-Type:
-      - application/json; charset=utf-8
-      Transfer-Encoding:
-      - chunked
-      Status:
-      - 404 Not Found
-      X-Ratelimit-Limit:
-      - '5000'
-      X-Ratelimit-Remaining:
-      - '4998'
-      X-Ratelimit-Reset:
-      - '1417535394'
-      X-Github-Media-Type:
-      - github.v3; format=json
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - deny
-      Content-Security-Policy:
-      - default-src 'none'
-      Access-Control-Allow-Credentials:
-      - 'true'
-      Access-Control-Expose-Headers:
-      - ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
-        X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
-      Access-Control-Allow-Origin:
-      - "*"
-      X-Github-Request-Id:
-      - 60178CA6:15D5:4C602DF:547DD33C
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubdomains; preload
-      X-Content-Type-Options:
-      - nosniff
-    body:
-      encoding: UTF-8
-      string: '{"message":"Not Found","documentation_url":"https://developer.github.com/v3/issues/labels/#add-labels-to-an-issue"}'
-    http_version: 
-  recorded_at: Tue, 02 Dec 2014 14:57:00 GMT
+  recorded_at: Tue, 16 Dec 2014 16:13:19 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/successful_clacheck_long_commit.yml
+++ b/spec/fixtures/vcr_cassettes/successful_clacheck_long_commit.yml
@@ -21,7 +21,7 @@ http_interactions:
       Server:
       - nginx/1.4.6 (Ubuntu)
       Date:
-      - Tue, 16 Dec 2014 16:18:16 GMT
+      - Mon, 05 Jan 2015 21:31:31 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -39,7 +39,7 @@ http_interactions:
       string: '{"status":"success","status_human":"Success","message":"All commit
         authors have signed the CLA or are members of Elasticsearch"}'
     http_version: 
-  recorded_at: Tue, 16 Dec 2014 16:13:18 GMT
+  recorded_at: Mon, 05 Jan 2015 21:25:38 GMT
 - request:
     method: get
     uri: https://test.local/jordansissel/this-is-only-a-test/pull/4.patch
@@ -61,7 +61,7 @@ http_interactions:
       Server:
       - GitHub.com
       Date:
-      - Tue, 16 Dec 2014 16:13:18 GMT
+      - Mon, 05 Jan 2015 21:25:38 GMT
       Content-Type:
       - text/plain; charset=utf-8
       Transfer-Encoding:
@@ -89,19 +89,19 @@ http_interactions:
       X-Ua-Compatible:
       - IE=Edge,chrome=1
       X-Request-Id:
-      - e01aa6416dc9414b519df3ff5afb8249
+      - 1f5263bae1f70249691653237f258e29
       X-Runtime:
-      - '0.031448'
+      - '0.029353'
       X-Rack-Cache:
       - miss
       X-Github-Request-Id:
-      - 428224B6:11C0:19FB394:54905A1E
+      - C0DEBD91:4818:6B28D4:54AB0152
       Strict-Transport-Security:
       - max-age=31536000; includeSubdomains; preload
       X-Content-Type-Options:
       - nosniff
       X-Served-By:
-      - a128136e4734a9f74c013356c773ece7
+      - 3f38dada85f97412f7f824e59f77fa9d
     body:
       encoding: UTF-8
       string: |
@@ -129,5 +129,5 @@ http_interactions:
         +Long commit?
          Sat Sep 27 04:42:57 UTC 2014
     http_version: 
-  recorded_at: Tue, 16 Dec 2014 16:13:19 GMT
+  recorded_at: Mon, 05 Jan 2015 21:25:38 GMT
 recorded_with: VCR 2.9.3

--- a/spec/lita/handlers/jls_spec.rb
+++ b/spec/lita/handlers/jls_spec.rb
@@ -62,7 +62,7 @@ describe Lita::Handlers::Jls, :lita_handler => true do
       original_git = subject.method(:git)
 
       allow(subject.config).to receive(:cla_uri).and_return(ENV['ELASTICSEARCH_CLA_URL'])
-      # allow(subject.config).to receive(:cla_uri).and_return('http://<CREDENTIALS>@<HOST>/verify/pull_request')
+
       allow(subject).to receive(:git).with(any_args) do |gitdir, *args|
         # Ignore any 'git push' attempts
         if args[0] == "push" # git("push", ...)
@@ -74,7 +74,7 @@ describe Lita::Handlers::Jls, :lita_handler => true do
     end
 
     it "should reply successfully if the merge works" do
-      VCR.use_cassette("successful_clacheck", :tags => [:internal]) do
+      VCR.use_cassette("successful_clacheck", :tag => :internal, :match_requests_on => [:path]) do
         allow(subject).to receive(:github_issue_label) { nil }
         allow(subject).to receive(:github_issue_comment) { nil }
 
@@ -86,7 +86,7 @@ describe Lita::Handlers::Jls, :lita_handler => true do
     end
 
     it "should properly handle long commit messages" do
-      VCR.use_cassette("successful_clacheck_long_commit", :tags => [:internal]) do
+      VCR.use_cassette("successful_clacheck_long_commit", :tag => :internal, :match_requests_on => [:path]) do
         allow(subject).to receive(:github_issue_comment) { nil }
         send_command("merge https://github.com/jordansissel/this-is-only-a-test/pull/4 master")
         insist { replies.last } == "(success) jordansissel/this-is-only-a-test#4 merged into: master"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@ require "coveralls"
 require "vcr"
 require "lita/rspec"
 require "lita-jls"
+require "uri"
 
 Lita.version_3_compatibility_mode = false
 
@@ -17,4 +18,14 @@ VCR.configure do |config|
   config.cassette_library_dir = File.join(File.dirname(__FILE__), 'fixtures', 'vcr_cassettes')
   config.hook_into :webmock
   # config.debug_logger = true
+  
+  config.before_record do |interaction|
+    interaction.response.headers.delete('Set-Cookie')
+    interaction.request.headers.delete('Authorization')
+  end
+
+  config.before_record(:internal) do |interaction|
+    uri = URI.parse(interaction.request.uri)
+    interaction.request.uri.sub!(/:\/\/.*#{Regexp.escape(uri.host)}/, "://test.local" )
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,7 +17,7 @@ SimpleCov.start { add_filter "/spec/" }
 VCR.configure do |config|
   config.cassette_library_dir = File.join(File.dirname(__FILE__), 'fixtures', 'vcr_cassettes')
   config.hook_into :webmock
-  # config.debug_logger = true
+ # config.debug_logger = true
   
   config.before_record do |interaction|
     interaction.response.headers.delete('Set-Cookie')


### PR DESCRIPTION
Remove the manual logstash check and use the clacheck API.
Added logic to clear VCR fixtures form any access tokens (before this commit it was a manual process)